### PR TITLE
remove version pin for PyGithub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ requests
 rich
 pyjwt
 joern2sarif
-PyGitHub==1.54.0.1
+PyGitHub


### PR DESCRIPTION
This interferes with updating other users of this package. (namely sast-scan)